### PR TITLE
Rewrite v2.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
-PREFIX=/usr/local/share/man/man3
-TARGETS=$(PREFIX)/jsmn-find.3
+PREFIX  = /usr/local/share/man/man3
+MANPAGE = jsmn-find.3
+
+DOCS_DIR = docs
+LOCAL    = $(DOCS_DIR)/$(MANPAGE)
+TARGETS  = $(PREFIX)/$(MANPAGE)
 
 install: $(TARGETS)
 
 uninstall:
 	rm -rf $(TARGETS)
 
-$(PREFIX)/jsmn-find.3:
-	cp doc/jsmn-find.3 $(PREFIX)/jsmn-find.3
+$(TARGETS): $(LOCAL)
+	cp $< $@
 
 .PHONY: install uninstall

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jsmntok_t tokens[256];
 
 jsmn_init(&parser);
 
-r jsmn_parse(&parser, json, strlen(json), tokens, 256);
+r = jsmn_parse(&parser, json, strlen(json), tokens, 256);
 if (r < 0) error();
 
 // populate jsmnf_pairs with the jsmn tokens
@@ -51,15 +51,15 @@ if (r < 0) error();
 jsmnf_pair *f;
 
 // assume the JSON : { "foo": { "bar": [ true, null, null ] } }
-if ((f = jsmnf_find(pairs, "foo", strlen("foo")))) {
+if ((f = jsmnf_find(pairs, json, "foo", strlen("foo")))) {
     // Found: { "bar" : [ true, null, null ] }
-    printf("Found: %.*s\n", f->value.length, f->value.contents);
-    if ((f = jsmnf_find(f, "bar", 3))) {
+    printf("Found: %.*s\n", f->value.end - f->value.start, json + f->value.start);
+    if ((f = jsmnf_find(f, json, "bar", 3))) {
         // Found: [ true, null, null ]
-        printf("Found: %.*s\n", f->value.length, f->value.contents);
-        if ((f = jsmn_find(f, "0", 1))) {
+        printf("Found: %.*s\n", f->value.end - f->value.start, json + f->value.start);
+        if ((f = jsmn_find(f, json, "0", 1))) {
             // Found: true
-            printf("Found: %.*s\n", f->value.length, f->value.contents);
+            printf("Found: %.*s\n", f->value.end - f->value.start, json + f->value.start);
         }
     }
 }
@@ -72,10 +72,10 @@ jsmnf_pair *f;
 // assume the JSON : [ null, [ true, null, null ] ]
 f = &pairs->buckets[1];
 // Found: [ true, null, null ]
-printf("Found: %.*s\n", f->value.length, f->value.contents);
+printf("Found: %.*s\n", f->value.end - f->value.start, json + f->value.start);
 f = &f->buckets[0];
 // Found: true
-printf("Found: %.*s\n", f->value.length, f->value.contents);
+printf("Found: %.*s\n", f->value.end - f->value.start, json + f->value.start);
 ```
 
 `find path (key search for objects and arrays)`
@@ -86,7 +86,7 @@ jsmnf_pair *f;
 // assume the JSON : [ 1, 2, [ 1, [ { "b":true } ] ] ]
 if ((f = jsmnf_find_path(pairs, path, sizeof(path) / sizeof *path))) {
     // Found: true
-    printf("Found: %.*s\n", f->value.length, f->value.contents);
+    printf("Found: %.*s\n", f->value.end - f->value.start, json + f->value.start);
 }
 ```
 

--- a/docs/jsmn-find.3
+++ b/docs/jsmn-find.3
@@ -6,22 +6,22 @@
 .br
 .BI "void jsmnf_init(jsmnf_loader *" "loader" ");"
 .br
-.BI "int jsmnf_load(jsmnf_loader *" "loader" ", const char " "js" "[], \
+.BI "int jsmnf_load(jsmnf_loader *" "loader" ", const char *" "js" ", \
 jsmntok_t " "tokens" "[], "
 .br
 .BI "                unsigned " "num_tokens" ", jsmnf_pair " \
 "pairs" "[], unsigned " "num_pairs" ");"
 .br
-.BI "jsmnf_pair *jsmnf_find(jsmnf_pair *" "head" ", const char " "key" \
-"[], int " "length" ");"
+.BI "jsmnf_pair *jsmnf_find(jsmnf_pair *" "head" ", const char *" "js" ", \
+const char " "key" "[], int " "length" ");"
 .br
-.BI "jsmnf_pair *jsmnf_find_path(jsmnf_pair *" "head" ", char *const " "path" \
-"[], int " "depth" ");"
+.BI "jsmnf_pair *jsmnf_find_path(jsmnf_pair *" "head" ", const char *" "js" \
+", char *const " "path" "[], int " "depth" ");"
 .br
-.BI "int jsmnf_parse_auto(jsmnf_parser *" "parser" ", const char " "js" "[], \
-size_t " "len" ", jsmntok_t **" "p_tokens" ", unsigned *" "num_tokens" ");"
+.BI "int jsmnf_parse_auto(jsmnf_parser *" "parser" ", const char *" "js" ", \
+size_t " "length" ", jsmntok_t **" "p_tokens" ", unsigned *" "num_tokens" ");"
 .br
-.BI "int jsmnf_load_auto(jsmnf_loader *" "loader" ", const char " "js" "[], \
+.BI "int jsmnf_load_auto(jsmnf_loader *" "loader" ", const char *" "js" ", \
 jsmntok_t " "tokens" "[], unsigned " "num_tokens" ", jsmnf_pair **" \
 "p_pairs" ", unsigned *" "num_pairs" ");"
 .br
@@ -133,7 +133,7 @@ int main(void) {
 .br
     // Found: { "bar" : [ 1, 2, 3 ] }
 .br
-    printf("Found: %.*s\\n", f->value.length, f->value.contents);
+    printf("Found: %.*s\\n", f->value.end - f->value.start, json + f->value.start);
 .br
 
     ...
@@ -147,7 +147,7 @@ int main(void) {
 
     // Found: true
 .br
-    printf("Found: %.*s\\n", f->value.length, f->value.contents);
+    printf("Found: %.*s\\n", f->value.end - f->value.start, json + f->value.start);
 .br
 }
 .br

--- a/jsmn-find.h
+++ b/jsmn-find.h
@@ -9,29 +9,28 @@ extern "C" {
 #error "jsmn-find.h should be included after jsmn.h"
 #endif
 
-/** @brief Internally used sized-buffer */
-struct _jsmnf_szbuf {
-    /** buffer's contents */
-    const char *contents;
-    /** buffer's length */
-    int length;
+/** @brief JSON token description */
+struct jsmnftok {
+    /** start position in JSON data string */
+    int start;
+    /** end position in JSON data string */
+    int end;
 };
 
 /** @brief JSON object */
 typedef struct jsmnf_pair {
-    /** JSON type @see `jsmntype_t` at jsmn.h */
-    jsmntype_t type;
     /** amount of children currently filled in */
     int length;
     /** children threshold capacity */
     int capacity;
     /** this pair's children */
     struct jsmnf_pair *buckets;
-
+    /** JSON type @see `jsmntype_t` at jsmn.h */
+    jsmntype_t type;
     /** the key of the pair */
-    struct _jsmnf_szbuf key;
+    struct jsmnftok key;
     /** the value of the pair */
-    struct _jsmnf_szbuf value;
+    struct jsmnftok value;
     /** current state of this pair */
     int state;
 } jsmnf_pair;
@@ -54,7 +53,7 @@ JSMN_API void jsmnf_init(jsmnf_loader *loader);
  * @brief Populate the @ref jsmnf_pair pairs from jsmn tokens
  *
  * @param[in,out] loader the @ref jsmnf_loader initialized with jsmnf_init()
- * @param[in] js the raw JSON string
+ * @param[in] js the JSON data string
  * @param[in] tokens jsmn tokens initialized with jsmn_parse() /
  *      jsmn_parse_auto()
  * @param[in] num_tokens amount of tokens initialized with jsmn_parse() /
@@ -64,7 +63,7 @@ JSMN_API void jsmnf_init(jsmnf_loader *loader);
  * @return a `enum jsmnerr` value for error or the amount of `pairs` used
  */
 JSMN_API int jsmnf_load(jsmnf_loader *loader,
-                        const char js[],
+                        const char *js,
                         const jsmntok_t tokens[],
                         unsigned num_tokens,
                         jsmnf_pair pairs[],
@@ -74,12 +73,14 @@ JSMN_API int jsmnf_load(jsmnf_loader *loader,
  * @brief Find a @ref jsmnf_pair token by its associated key
  *
  * @param[in] head a @ref jsmnf_pair object or array loaded at jsmnf_start()
+ * @param[in] js the JSON data string
  * @param[in] key the key too be matched
  * @param[in] length length of the key too be matched
  * @return the @ref jsmnf_pair `head`'s field matched to `key`, or NULL if
  * not encountered
  */
 JSMN_API jsmnf_pair *jsmnf_find(const jsmnf_pair *head,
+                                const char *js,
                                 const char key[],
                                 int length);
 
@@ -87,14 +88,16 @@ JSMN_API jsmnf_pair *jsmnf_find(const jsmnf_pair *head,
  * @brief Find a @ref jsmnf_pair token by its full key path
  *
  * @param[in] head a @ref jsmnf_pair object or array loaded at jsmnf_start()
+ * @param[in] js the JSON data string
  * @param[in] path an array of key path strings, from least to highest depth
  * @param[in] depth the depth level of the last `path` key
  * @return the @ref jsmnf_pair `head`'s field matched to `path`, or NULL if
  * not encountered
  */
 JSMN_API jsmnf_pair *jsmnf_find_path(const jsmnf_pair *head,
+                                     const char *js,
                                      char *const path[],
-                                     int depth);
+                                     unsigned depth);
 
 /**
  * @brief Populate and automatically allocate the @ref jsmnf_pair pairs from
@@ -103,7 +106,7 @@ JSMN_API jsmnf_pair *jsmnf_find_path(const jsmnf_pair *head,
  *      amount of pairs necessary for sorting the JSON tokens
  *
  * @param[in,out] loader the @ref jsmnf_loader initialized with jsmnf_init()
- * @param[in] js the raw JSON string
+ * @param[in] js the JSON data string
  * @param[in] tokens jsmn tokens initialized with jsmn_parse() /
  *      jsmn_parse_auto()
  * @param[in] num_tokens amount of tokens initialized with jsmn_parse() /
@@ -114,7 +117,7 @@ JSMN_API jsmnf_pair *jsmnf_find_path(const jsmnf_pair *head,
  * @return a `enum jsmnerr` value for error or the amount of `pairs` used
  */
 JSMN_API int jsmnf_load_auto(jsmnf_loader *loader,
-                             const char js[],
+                             const char *js,
                              const jsmntok_t tokens[],
                              unsigned num_tokens,
                              jsmnf_pair **p_pairs,
@@ -125,8 +128,8 @@ JSMN_API int jsmnf_load_auto(jsmnf_loader *loader,
  *      amount of tokens necessary for parsing the JSON string
  *
  * @param[in,out] parser the `jsmn_parser` initialized with `jsmn_init()`
- * @param[in] js the raw JSON string
- * @param[in] len the raw JSON string length
+ * @param[in] js the JSON data string
+ * @param[in] length the raw JSON string length
  * @param[out] p_tokens pointer to `jsmntok_t` to be dynamically increased
  *      @note must be `free()`'d once done being used
  * @param[in,out] num_tokens amount of tokens
@@ -134,7 +137,7 @@ JSMN_API int jsmnf_load_auto(jsmnf_loader *loader,
  */
 JSMN_API int jsmn_parse_auto(jsmn_parser *parser,
                              const char *js,
-                             size_t len,
+                             size_t length,
                              jsmntok_t **p_tokens,
                              unsigned *num_tokens);
 
@@ -163,17 +166,18 @@ JSMN_API long jsmnf_unescape(char buf[],
 #define _jsmnf_key_hash(key, hash)                                            \
     5031;                                                                     \
     do {                                                                      \
-        int __CHASH_HINDEX;                                                   \
-        for (__CHASH_HINDEX = 0; __CHASH_HINDEX < (key).length;               \
-             ++__CHASH_HINDEX) {                                              \
-            (hash) =                                                          \
-                (((hash) << 1) + (hash)) + (key).contents[__CHASH_HINDEX];    \
+        unsigned __CHASH_HINDEX;                                              \
+        unsigned _len = (key).end - (key).start;                              \
+        for (__CHASH_HINDEX = 0; __CHASH_HINDEX < _len; ++__CHASH_HINDEX) {   \
+            (hash) = (((hash) << 1) + (hash))                                 \
+                     + _JSMNF_STRING_B[(key).start + __CHASH_HINDEX];         \
         }                                                                     \
     } while (0)
 
 /* compare jsmnf keys */
 #define _jsmnf_key_compare(cmp_a, cmp_b)                                      \
-    (!strncmp((cmp_a).contents, (cmp_b).contents, (cmp_b).length))
+    (!strncmp(_JSMNF_STRING_B + (cmp_a).start,                                \
+              _JSMNF_STRING_A + (cmp_b).start, (cmp_b).end - (cmp_b).start))
 
 #define _JSMNF_TABLE_HEAP   0
 #define _JSMNF_TABLE_BUCKET struct jsmnf_pair
@@ -190,10 +194,13 @@ jsmnf_init(jsmnf_loader *loader)
     loader->pairnext = 0;
 }
 
+#define _JSMNF_STRING_A js
+#define _JSMNF_STRING_B js
+
 static int
 _jsmnf_load_pairs(struct jsmnf_loader *loader,
+                  const char *js,
                   struct jsmnf_pair *curr,
-                  const char js[],
                   const struct jsmntok *tok,
                   unsigned num_tokens,
                   struct jsmnf_pair *pairs,
@@ -208,7 +215,7 @@ _jsmnf_load_pairs(struct jsmnf_loader *loader,
     case JSMN_PRIMITIVE:
         break;
     default: { /* should be either JSMN_ARRAY or JSMN_OBJECT */
-        const unsigned top_idx = loader->pairnext + 1 + (tok->size * 1.3),
+        const unsigned top_idx = loader->pairnext + (1 + tok->size),
                        bottom_idx = loader->pairnext;
         int ret;
 
@@ -227,10 +234,10 @@ _jsmnf_load_pairs(struct jsmnf_loader *loader,
             while (curr->length < tok->size) {
                 const struct jsmntok *_key = tok + 1 + offset;
                 struct jsmnf_pair *found = NULL;
-                struct _jsmnf_szbuf key, value = { 0 };
+                struct jsmnftok key, value = { 0 };
 
-                key.contents = js + _key->start;
-                key.length = _key->end - _key->start;
+                key.start = _key->start;
+                key.end = _key->end;
 
                 /* skip Key token */
                 offset += 1;
@@ -240,13 +247,13 @@ _jsmnf_load_pairs(struct jsmnf_loader *loader,
                 if (_key->size > 0) {
                     const struct jsmntok *_value = tok + 1 + offset;
 
-                    value.contents = js + _value->start;
-                    value.length = _value->end - _value->start;
+                    value.start = _value->start;
+                    value.end = _value->end;
 
                     chash_assign(curr, key, value, _JSMNF_TABLE);
                     (void)chash_lookup_bucket(curr, key, found, _JSMNF_TABLE);
 
-                    ret = _jsmnf_load_pairs(loader, found, js, _value,
+                    ret = _jsmnf_load_pairs(loader, js, found, _value,
                                             num_tokens - offset, pairs,
                                             num_pairs);
                     if (ret < 0) return ret;
@@ -264,12 +271,12 @@ _jsmnf_load_pairs(struct jsmnf_loader *loader,
             for (; curr->length < tok->size; ++curr->length) {
                 const struct jsmntok *_value = tok + 1 + offset;
                 struct jsmnf_pair *pair = curr->buckets + curr->length;
-                struct _jsmnf_szbuf value;
+                struct jsmnftok value;
 
-                value.contents = js + _value->start;
-                value.length = _value->end - _value->start;
+                value.start = _value->start;
+                value.end = _value->end;
 
-                ret = _jsmnf_load_pairs(loader, pair, js, _value,
+                ret = _jsmnf_load_pairs(loader, js, pair, _value,
                                         num_tokens - offset, pairs, num_pairs);
                 if (ret < 0) return ret;
 
@@ -279,8 +286,8 @@ _jsmnf_load_pairs(struct jsmnf_loader *loader,
                 pair->value = value;
                 pair->state = CHASH_FILLED;
                 /* unused for array elements */
-                pair->key.contents = NULL;
-                pair->key.length = 0;
+                pair->key.start = 0;
+                pair->key.end = 0;
             }
         }
         break;
@@ -297,9 +304,12 @@ _jsmnf_load_pairs(struct jsmnf_loader *loader,
     return offset + 1;
 }
 
+#undef _JSMNF_STRING_A
+#undef _JSMNF_STRING_B
+
 JSMN_API int
 jsmnf_load(struct jsmnf_loader *loader,
-           const char js[],
+           const char *js,
            const struct jsmntok tokens[],
            unsigned num_tokens,
            struct jsmnf_pair pairs[],
@@ -314,13 +324,13 @@ jsmnf_load(struct jsmnf_loader *loader,
         for (; i < num_pairs; ++i)
             pairs[i] = blank_pair;
         /* root */
-        pairs[0].value.contents = js + tokens->start;
-        pairs[0].value.length = tokens->end - tokens->start;
+        pairs[0].value.start = tokens->start;
+        pairs[0].value.end = tokens->end;
 
         ++loader->pairnext;
     }
 
-    ret = _jsmnf_load_pairs(loader, pairs, js, tokens, num_tokens, pairs,
+    ret = _jsmnf_load_pairs(loader, js, pairs, tokens, num_tokens, pairs,
                             num_pairs);
 
     /* TODO: rather than reseting pairnext keep the last 'bucket' ptr stored,
@@ -329,18 +339,26 @@ jsmnf_load(struct jsmnf_loader *loader,
     return ret;
 }
 
+#define _JSMNF_STRING_A js
+#define _JSMNF_STRING_B key
+
 JSMN_API struct jsmnf_pair *
-jsmnf_find(const struct jsmnf_pair *head, const char key[], int length)
+jsmnf_find(const struct jsmnf_pair *head,
+           const char *js,
+           const char key[],
+           int length)
 {
     struct jsmnf_pair *found = NULL;
 
     if (!key || !head) return NULL;
 
     if (JSMN_OBJECT == head->type) {
-        struct _jsmnf_szbuf _key;
+        struct jsmnftok _key;
         int contains;
-        _key.contents = key;
-        _key.length = length;
+
+        _key.start = 0;
+        _key.end = length;
+
         contains = chash_contains(head, _key, contains, _JSMNF_TABLE);
         if (contains) {
             (void)chash_lookup_bucket(head, _key, found, _JSMNF_TABLE);
@@ -349,21 +367,27 @@ jsmnf_find(const struct jsmnf_pair *head, const char key[], int length)
     else if (JSMN_ARRAY == head->type) {
         char *endptr;
         int idx = (int)strtol(key, &endptr, 10);
-        if (endptr != key) found = head->buckets + idx;
+        if (endptr != key && idx < head->length) found = head->buckets + idx;
     }
     return found;
 }
 
+#undef _JSMNF_STRING_A
+#undef _JSMNF_STRING_B
+
 JSMN_API struct jsmnf_pair *
-jsmnf_find_path(const struct jsmnf_pair *head, char *const path[], int depth)
+jsmnf_find_path(const struct jsmnf_pair *head,
+                const char *js,
+                char *const path[],
+                unsigned depth)
 {
     const struct jsmnf_pair *iter = head;
     struct jsmnf_pair *found = NULL;
-    int i;
+    unsigned i;
 
     for (i = 0; i < depth; ++i) {
         if (!iter) continue;
-        found = jsmnf_find(iter, path[i], strlen(path[i]));
+        found = jsmnf_find(iter, js, path[i], strlen(path[i]));
         if (!found) break;
         iter = found;
     }
@@ -373,7 +397,7 @@ jsmnf_find_path(const struct jsmnf_pair *head, char *const path[], int depth)
 JSMN_API int
 jsmn_parse_auto(struct jsmn_parser *parser,
                 const char *js,
-                size_t len,
+                size_t length,
                 struct jsmntok **p_tokens,
                 unsigned *num_tokens)
 {
@@ -385,7 +409,7 @@ jsmn_parse_auto(struct jsmn_parser *parser,
     }
 
     while (1) {
-        ret = jsmn_parse(parser, js, len, *p_tokens, *num_tokens);
+        ret = jsmn_parse(parser, js, length, *p_tokens, *num_tokens);
         if (ret != JSMN_ERROR_NOMEM) {
             break;
         }
@@ -405,7 +429,7 @@ jsmn_parse_auto(struct jsmn_parser *parser,
 
 JSMN_API int
 jsmnf_load_auto(struct jsmnf_loader *loader,
-                const char js[],
+                const char *js,
                 const struct jsmntok tokens[],
                 unsigned num_tokens,
                 struct jsmnf_pair **p_pairs,

--- a/test/functions.c
+++ b/test/functions.c
@@ -31,8 +31,8 @@ print_jsmnerr(enum jsmnerr code)
 TEST
 check_load_dynamic_pairs(void)
 {
-    const char json_small[] = "{\"foo\":[true]}";
-    const char json_large[] = "{\"foo\":{\"bar\":{\"baz\":[true]}}}";
+    const char js_small[] = "{\"foo\":[true]}";
+    const char js_large[] = "{\"foo\":{\"bar\":{\"baz\":[true]}}}";
     jsmn_parser parser;
     jsmntok_t toks[64];
     jsmnf_loader loader;
@@ -43,39 +43,43 @@ check_load_dynamic_pairs(void)
     jsmn_init(&parser);
     jsmnf_init(&loader);
 
-    jsmn_parse(&parser, json_small, sizeof(json_small) - 1, toks,
+    jsmn_parse(&parser, js_small, sizeof(js_small) - 1, toks,
                sizeof(toks) / sizeof *toks);
 
     ASSERT_GTm(print_jsmnerr(ret),
-               ret = jsmnf_load_auto(&loader, json_small, toks, parser.toknext,
+               ret = jsmnf_load_auto(&loader, js_small, toks, parser.toknext,
                                      &pairs, &num_pairs),
                0);
 
-    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, "foo", sizeof("foo") - 1));
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "0", sizeof("0") - 1));
-    ASSERT_EQm("Array elements shouldn't have a key", 0, f->key.length);
-    ASSERT_STRN_EQ("true", f->value.contents, f->value.length);
+    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, js_small, "foo", 3));
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js_small, "0", 1));
+    ASSERT_EQm("Array elements shouldn't have a key", 0,
+               f->key.end - f->key.start);
+    ASSERT_STRN_EQ("true", js_small + f->value.start,
+                   f->value.end - f->value.start);
 
     jsmn_init(&parser);
     jsmnf_init(&loader);
 
-    jsmn_parse(&parser, json_large, sizeof(json_large) - 1, toks,
+    jsmn_parse(&parser, js_large, sizeof(js_large) - 1, toks,
                sizeof(toks) / sizeof *toks);
 
     ASSERT_GTm(print_jsmnerr(ret),
-               ret = jsmnf_load_auto(&loader, json_large, toks, parser.toknext,
+               ret = jsmnf_load_auto(&loader, js_large, toks, parser.toknext,
                                      &pairs, &num_pairs),
                0);
 
-    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, "foo", sizeof("foo") - 1));
-    ASSERT_STRN_EQ("foo", f->key.contents, f->key.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "bar", sizeof("bar") - 1));
-    ASSERT_STRN_EQ("bar", f->key.contents, f->key.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "baz", sizeof("baz") - 1));
-    ASSERT_STRN_EQ("baz", f->key.contents, f->key.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "0", sizeof("0") - 1));
-    ASSERT_EQm("Array elements shouldn't have a key", 0, f->key.length);
-    ASSERT_STRN_EQ("true", f->value.contents, f->value.length);
+    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, js_large, "foo", 3));
+    ASSERT_STRN_EQ("foo", js_large + f->key.start, f->key.end - f->key.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js_large, "bar", 3));
+    ASSERT_STRN_EQ("bar", js_large + f->key.start, f->key.end - f->key.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js_large, "baz", 3));
+    ASSERT_STRN_EQ("baz", js_large + f->key.start, f->key.end - f->key.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js_large, "0", 1));
+    ASSERT_EQm("Array elements shouldn't have a key", 0,
+               f->key.end - f->key.start);
+    ASSERT_STRN_EQ("true", js_large + f->value.start,
+                   f->value.end - f->value.start);
 
     free(pairs);
 
@@ -85,8 +89,8 @@ check_load_dynamic_pairs(void)
 TEST
 check_load_dynamic_pairs_and_tokens(void)
 {
-    const char json_small[] = "{\"foo\":[true]}";
-    const char json_large[] = "{\"foo\":{\"bar\":{\"baz\":[true]}}}";
+    const char js_small[] = "{\"foo\":[true]}";
+    const char js_large[] = "{\"foo\":{\"bar\":{\"baz\":[true]}}}";
     jsmn_parser parser;
     jsmntok_t *toks = NULL;
     jsmnf_loader loader;
@@ -98,42 +102,45 @@ check_load_dynamic_pairs_and_tokens(void)
     jsmnf_init(&loader);
 
     ASSERT_GTm(print_jsmnerr(ret),
-               ret = jsmn_parse_auto(&parser, json_small,
-                                     sizeof(json_small) - 1, &toks, &num_tokens),
+               ret = jsmn_parse_auto(&parser, js_small, sizeof(js_small) - 1,
+                                     &toks, &num_tokens),
                0);
 
     ASSERT_GTm(print_jsmnerr(ret),
-               ret = jsmnf_load_auto(&loader, json_small, toks, num_tokens,
+               ret = jsmnf_load_auto(&loader, js_small, toks, num_tokens,
                                      &pairs, &num_pairs),
                0);
 
-    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, "foo", sizeof("foo") - 1));
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "0", sizeof("0") - 1));
-    ASSERT_EQm("Array elements shouldn't have a key", 0, f->key.length);
-    ASSERT_STRN_EQ("true", f->value.contents, f->value.length);
+    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, js_small, "foo", 3));
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js_small, "0", 1));
+    ASSERT_EQm("Array elements shouldn't have a key", 0,
+               f->key.end - f->key.start);
+    ASSERT_STRN_EQ("true", js_small + f->value.start,
+                   f->value.end - f->value.start);
 
     jsmn_init(&parser);
     jsmnf_init(&loader);
 
     ASSERT_GTm(print_jsmnerr(ret),
-               ret =
-                   jsmn_parse_auto(&parser, json_large, sizeof(json_large) - 1,
-                                   &toks, &num_tokens),
+               ret = jsmn_parse_auto(&parser, js_large, sizeof(js_large) - 1,
+                                     &toks, &num_tokens),
                0);
     ASSERT_GTm(print_jsmnerr(ret),
-               ret = jsmnf_load_auto(&loader, json_large, toks, parser.toknext,
+               ret = jsmnf_load_auto(&loader, js_large, toks, parser.toknext,
                                      &pairs, &num_pairs),
                0);
 
-    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, "foo", sizeof("foo") - 1));
-    ASSERT_STRN_EQ("foo", f->key.contents, f->key.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "bar", sizeof("bar") - 1));
-    ASSERT_STRN_EQ("bar", f->key.contents, f->key.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "baz", sizeof("baz") - 1));
-    ASSERT_STRN_EQ("baz", f->key.contents, f->key.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "0", sizeof("0") - 1));
-    ASSERT_EQm("Array elements shouldn't have a key", 0, f->key.length);
-    ASSERT_STRN_EQ("true", f->value.contents, f->value.length);
+    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, js_large, "foo", 3));
+    ASSERT_STRN_EQ("foo", js_large + f->key.start, f->key.end - f->key.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js_large, "bar", 3));
+    ASSERT_STRN_EQ("bar", js_large + f->key.start, f->key.end - f->key.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js_large, "baz", 3));
+    ASSERT_STRN_EQ("baz", js_large + f->key.start, f->key.end - f->key.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js_large, "0", 1));
+    ASSERT_EQm("Array elements shouldn't have a key", 0,
+               f->key.end - f->key.start);
+    ASSERT_STRN_EQ("true", js_large + f->value.start,
+                   f->value.end - f->value.start);
 
     free(toks);
     free(pairs);
@@ -208,7 +215,7 @@ SUITE(fn__jsmnf_unescape)
 TEST
 check_load_not_enough_pairs_for_tokens(void)
 {
-    const char json[] = "{\"foo\":{\"bar\":{\"baz\":[true]}}}";
+    const char js[] = "{\"foo\":{\"bar\":{\"baz\":[true]}}}";
     jsmn_parser parser;
     jsmntok_t toks[64];
     jsmnf_loader loader;
@@ -218,29 +225,29 @@ check_load_not_enough_pairs_for_tokens(void)
     jsmn_init(&parser);
     jsmnf_init(&loader);
 
-    jsmn_parse(&parser, json, sizeof(json) - 1, toks,
-               sizeof(toks) / sizeof *toks);
+    jsmn_parse(&parser, js, sizeof(js) - 1, toks, sizeof(toks) / sizeof *toks);
 
     /* not enough pairs should return JSMN_ERROR_NOMEM */
     ASSERT_EQm(print_jsmnerr(ret), JSMN_ERROR_NOMEM,
-               ret = jsmnf_load(&loader, json, toks, parser.toknext, pairs,
+               ret = jsmnf_load(&loader, js, toks, parser.toknext, pairs,
                                 parser.toknext));
     /* simulate realloc */
     ASSERT_GTm(print_jsmnerr(ret),
-               ret = jsmnf_load(&loader, json, toks, parser.toknext, pairs,
+               ret = jsmnf_load(&loader, js, toks, parser.toknext, pairs,
                                 sizeof(pairs) / sizeof *pairs),
                0);
 
     /* check if searching still works */
-    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, "foo", sizeof("foo") - 1));
-    ASSERT_STRN_EQ("foo", f->key.contents, f->key.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "bar", sizeof("bar") - 1));
-    ASSERT_STRN_EQ("bar", f->key.contents, f->key.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "baz", sizeof("baz") - 1));
-    ASSERT_STRN_EQ("baz", f->key.contents, f->key.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "0", sizeof("0") - 1));
-    ASSERT_EQm("Array elements shouldn't have a key", 0, f->key.length);
-    ASSERT_STRN_EQ("true", f->value.contents, f->value.length);
+    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, js, "foo", 3));
+    ASSERT_STRN_EQ("foo", js + f->key.start, f->key.end - f->key.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js, "bar", 3));
+    ASSERT_STRN_EQ("bar", js + f->key.start, f->key.end - f->key.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js, "baz", 3));
+    ASSERT_STRN_EQ("baz", js + f->key.start, f->key.end - f->key.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js, "0", 1));
+    ASSERT_EQm("Array elements shouldn't have a key", 0,
+               f->key.end - f->key.start);
+    ASSERT_STRN_EQ("true", js + f->value.start, f->value.end - f->value.start);
 
     PASS();
 }
@@ -248,7 +255,7 @@ check_load_not_enough_pairs_for_tokens(void)
 TEST
 check_load_basic(void)
 {
-    const char json[] = "{\"a\":1,\"c\":{}}";
+    const char js[] = "{\"a\":1,\"c\":{}}";
 
     jsmn_parser parser;
     jsmntok_t toks[32];
@@ -259,16 +266,15 @@ check_load_basic(void)
     jsmn_init(&parser);
     jsmnf_init(&loader);
 
-    jsmn_parse(&parser, json, sizeof(json) - 1, toks,
-               sizeof(toks) / sizeof *toks);
+    jsmn_parse(&parser, js, sizeof(js) - 1, toks, sizeof(toks) / sizeof *toks);
 
     /* not enough pairs should return JSMN_ERROR_NOMEM */
     ASSERT_EQm(print_jsmnerr(ret), JSMN_ERROR_NOMEM,
-               ret = jsmnf_load(&loader, json, toks, parser.toknext, pairs,
+               ret = jsmnf_load(&loader, js, toks, parser.toknext, pairs,
                                 sizeof(pairs) / sizeof *pairs / 2));
     /* simulate realloc */
     ASSERT_GTm(print_jsmnerr(ret),
-               ret = jsmnf_load(&loader, json, toks, parser.toknext, pairs,
+               ret = jsmnf_load(&loader, js, toks, parser.toknext, pairs,
                                 sizeof(pairs) / sizeof *pairs),
                0);
 
@@ -278,7 +284,7 @@ check_load_basic(void)
 TEST
 check_load_array(void)
 {
-    const char json[] = "[1, [1, 2, [1, 2, 3, [true]]]]";
+    const char js[] = "[1, [1, 2, [1, 2, 3, [true]]]]";
     jsmn_parser parser;
     jsmntok_t toks[64];
     jsmnf_loader loader;
@@ -288,11 +294,10 @@ check_load_array(void)
     jsmn_init(&parser);
     jsmnf_init(&loader);
 
-    jsmn_parse(&parser, json, sizeof(json) - 1, toks,
-               sizeof(toks) / sizeof *toks);
+    jsmn_parse(&parser, js, sizeof(js) - 1, toks, sizeof(toks) / sizeof *toks);
 
     ASSERT_GTm(print_jsmnerr(ret),
-               ret = jsmnf_load(&loader, json, toks, parser.toknext, pairs,
+               ret = jsmnf_load(&loader, js, toks, parser.toknext, pairs,
                                 sizeof(pairs) / sizeof *pairs),
                0);
 
@@ -317,7 +322,7 @@ SUITE(fn__jsmnf_load)
 TEST
 check_find_nested(void)
 {
-    const char json[] = "{\"foo\":{\"bar\":{\"baz\":[true]}}}";
+    const char js[] = "{\"foo\":{\"bar\":{\"baz\":[true]}}}";
     jsmn_parser parser;
     jsmntok_t toks[64];
     jsmnf_loader loader;
@@ -326,21 +331,21 @@ check_find_nested(void)
     jsmn_init(&parser);
     jsmnf_init(&loader);
 
-    jsmn_parse(&parser, json, sizeof(json) - 1, toks,
-               sizeof(toks) / sizeof *toks);
+    jsmn_parse(&parser, js, sizeof(js) - 1, toks, sizeof(toks) / sizeof *toks);
 
-    jsmnf_load(&loader, json, toks, parser.toknext, pairs,
+    jsmnf_load(&loader, js, toks, parser.toknext, pairs,
                sizeof(pairs) / sizeof *pairs);
 
-    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, "foo", sizeof("foo") - 1));
-    ASSERT_STRN_EQ("foo", f->key.contents, f->key.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "bar", sizeof("bar") - 1));
-    ASSERT_STRN_EQ("bar", f->key.contents, f->key.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "baz", sizeof("baz") - 1));
-    ASSERT_STRN_EQ("baz", f->key.contents, f->key.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "0", sizeof("0") - 1));
-    ASSERT_EQm("Array elements shouldn't have a key", 0, f->key.length);
-    ASSERT_STRN_EQ("true", f->value.contents, f->value.length);
+    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, js, "foo", 3));
+    ASSERT_STRN_EQ("foo", js + f->key.start, f->key.end - f->key.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js, "bar", 3));
+    ASSERT_STRN_EQ("bar", js + f->key.start, f->key.end - f->key.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js, "baz", 3));
+    ASSERT_STRN_EQ("baz", js + f->key.start, f->key.end - f->key.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js, "0", 1));
+    ASSERT_EQm("Array elements shouldn't have a key", 0,
+               f->key.end - f->key.start);
+    ASSERT_STRN_EQ("true", js + f->value.start, f->value.end - f->value.start);
 
     PASS();
 }
@@ -348,7 +353,7 @@ check_find_nested(void)
 TEST
 check_find_array(void)
 {
-    const char json[] = "[1, [1, 2, [1, 2, 3, [true]]]]";
+    const char js[] = "[1, [1, 2, [1, 2, 3, [true]]]]";
     jsmn_parser parser;
     jsmntok_t toks[64];
     jsmnf_loader loader;
@@ -357,47 +362,48 @@ check_find_array(void)
     jsmn_init(&parser);
     jsmnf_init(&loader);
 
-    jsmn_parse(&parser, json, sizeof(json) - 1, toks,
-               sizeof(toks) / sizeof *toks);
+    jsmn_parse(&parser, js, sizeof(js) - 1, toks, sizeof(toks) / sizeof *toks);
 
-    jsmnf_load(&loader, json, toks, parser.toknext, pairs,
+    jsmnf_load(&loader, js, toks, parser.toknext, pairs,
                sizeof(pairs) / sizeof *pairs);
 
     /* test direct search */
     f = &pairs->buckets[0];
-    ASSERT_STRN_EQ("1", f->value.contents, f->value.length);
+    ASSERT_STRN_EQ("1", js + f->value.start, f->value.end - f->value.start);
     f = &pairs->buckets[1];
-    ASSERT_STRN_EQ("1", f->buckets[0].value.contents,
-                   f->buckets[0].value.length);
-    ASSERT_STRN_EQ("2", f->buckets[1].value.contents,
-                   f->buckets[1].value.length);
+    ASSERT_STRN_EQ("1", js + f->buckets[0].value.start,
+                   f->buckets[0].value.end - f->buckets[0].value.start);
+    ASSERT_STRN_EQ("2", js + f->buckets[1].value.start,
+                   f->buckets[1].value.end - f->buckets[1].value.start);
     f = &f->buckets[2];
-    ASSERT_STRN_EQ("1", f->buckets[0].value.contents,
-                   f->buckets[0].value.length);
-    ASSERT_STRN_EQ("2", f->buckets[1].value.contents,
-                   f->buckets[1].value.length);
-    ASSERT_STRN_EQ("3", f->buckets[2].value.contents,
-                   f->buckets[2].value.length);
+    ASSERT_STRN_EQ("1", js + f->buckets[0].value.start,
+                   f->buckets[0].value.end - f->buckets[0].value.start);
+    ASSERT_STRN_EQ("2", js + f->buckets[1].value.start,
+                   f->buckets[1].value.end - f->buckets[1].value.start);
+    ASSERT_STRN_EQ("3", js + f->buckets[2].value.start,
+                   f->buckets[2].value.end - f->buckets[2].value.start);
     f = &f->buckets[3];
-    ASSERT_STRN_EQ("[true]", f->value.contents, f->value.length);
+    ASSERT_STRN_EQ("[true]", js + f->value.start,
+                   f->value.end - f->value.start);
 
     /* test key search */
-    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, "0", 1));
-    ASSERT_STRN_EQ("1", f->value.contents, f->value.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, "1", 1));
-    ASSERT_STRN_EQ("1", f->buckets[0].value.contents,
-                   f->buckets[0].value.length);
-    ASSERT_STRN_EQ("2", f->buckets[1].value.contents,
-                   f->buckets[1].value.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "2", 1));
-    ASSERT_STRN_EQ("1", f->buckets[0].value.contents,
-                   f->buckets[0].value.length);
-    ASSERT_STRN_EQ("2", f->buckets[1].value.contents,
-                   f->buckets[1].value.length);
-    ASSERT_STRN_EQ("3", f->buckets[2].value.contents,
-                   f->buckets[2].value.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find(f, "3", 1));
-    ASSERT_STRN_EQ("[true]", f->value.contents, f->value.length);
+    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, js, "0", 1));
+    ASSERT_STRN_EQ("1", js + f->value.start, f->value.end - f->value.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find(pairs, js, "1", 1));
+    ASSERT_STRN_EQ("1", js + f->buckets[0].value.start,
+                   f->buckets[0].value.end - f->buckets[0].value.start);
+    ASSERT_STRN_EQ("2", js + f->buckets[1].value.start,
+                   f->buckets[1].value.end - f->buckets[1].value.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js, "2", 1));
+    ASSERT_STRN_EQ("1", js + f->buckets[0].value.start,
+                   f->buckets[0].value.end - f->buckets[0].value.start);
+    ASSERT_STRN_EQ("2", js + f->buckets[1].value.start,
+                   f->buckets[1].value.end - f->buckets[1].value.start);
+    ASSERT_STRN_EQ("3", js + f->buckets[2].value.start,
+                   f->buckets[2].value.end - f->buckets[2].value.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find(f, js, "3", 1));
+    ASSERT_STRN_EQ("[true]", js + f->value.start,
+                   f->value.end - f->value.start);
 
     PASS();
 }
@@ -405,7 +411,7 @@ check_find_array(void)
 TEST
 check_find_string_elements_in_array(void)
 {
-    const char json[] = "{\"modules\":[\"foo\",\"bar\",\"baz\",\"tuna\"]}";
+    const char js[] = "{\"modules\":[\"foo\",\"bar\",\"baz\",\"tuna\"]}";
     jsmn_parser parser;
     jsmntok_t toks[64];
     jsmnf_loader loader;
@@ -414,24 +420,26 @@ check_find_string_elements_in_array(void)
     jsmn_init(&parser);
     jsmnf_init(&loader);
 
-    jsmn_parse(&parser, json, sizeof(json) - 1, toks,
-               sizeof(toks) / sizeof *toks);
+    jsmn_parse(&parser, js, sizeof(js) - 1, toks, sizeof(toks) / sizeof *toks);
 
-    jsmnf_load(&loader, json, toks, parser.toknext, pairs,
+    jsmnf_load(&loader, js, toks, parser.toknext, pairs,
                sizeof(pairs) / sizeof *pairs);
 
-    ASSERT_NEQ(NULL, f1 = jsmnf_find(pairs, "modules", 7));
+    ASSERT_NEQ(NULL, f1 = jsmnf_find(pairs, js, "modules", 7));
 
     /* test direct search */
     f2 = &f1->buckets[0];
-    ASSERT_STRN_EQ("foo", f2->value.contents, f2->value.length);
+    ASSERT_STRN_EQ("foo", js + f2->value.start,
+                   f2->value.end - f2->value.start);
     f2 = &f1->buckets[1];
-    ASSERT_STRN_EQ("bar", f2->value.contents, f2->value.length);
+    ASSERT_STRN_EQ("bar", js + f2->value.start,
+                   f2->value.end - f2->value.start);
     f2 = &f1->buckets[2];
-    ASSERT_STRN_EQ("baz", f2->value.contents, f2->value.length);
+    ASSERT_STRN_EQ("baz", js + f2->value.start,
+                   f2->value.end - f2->value.start);
     f2 = &f1->buckets[3];
-    ASSERT_STRN_EQ("tuna", f2->value.contents, f2->value.length);
-
+    ASSERT_STRN_EQ("tuna", js + f2->value.start,
+                   f2->value.end - f2->value.start);
 
     PASS();
 }
@@ -446,7 +454,7 @@ SUITE(fn__jsmnf_find)
 TEST
 check_find_path_nested(void)
 {
-    const char json[] = "{\"foo\":{\"bar\":{\"baz\":[true]}}}";
+    const char js[] = "{\"foo\":{\"bar\":{\"baz\":[true]}}}";
     char *path[] = { "foo", "bar", "baz", "0" };
     jsmn_parser parser;
     jsmntok_t toks[64];
@@ -456,21 +464,21 @@ check_find_path_nested(void)
     jsmn_init(&parser);
     jsmnf_init(&loader);
 
-    jsmn_parse(&parser, json, sizeof(json) - 1, toks,
-               sizeof(toks) / sizeof *toks);
+    jsmn_parse(&parser, js, sizeof(js) - 1, toks, sizeof(toks) / sizeof *toks);
 
-    jsmnf_load(&loader, json, toks, parser.toknext, pairs,
+    jsmnf_load(&loader, js, toks, parser.toknext, pairs,
                sizeof(pairs) / sizeof *pairs);
 
-    ASSERT_NEQ(NULL, f = jsmnf_find_path(pairs, path, 1));
-    ASSERT_STRN_EQ(path[0], f->key.contents, f->key.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find_path(pairs, path, 2));
-    ASSERT_STRN_EQ(path[1], f->key.contents, f->key.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find_path(pairs, path, 3));
-    ASSERT_STRN_EQ(path[2], f->key.contents, f->key.length);
-    ASSERT_NEQ(NULL, f = jsmnf_find_path(pairs, path, 4));
-    ASSERT_EQm("Array elements shouldn't have a key", 0, f->key.length);
-    ASSERT_STRN_EQ("true", f->value.contents, f->value.length);
+    ASSERT_NEQ(NULL, f = jsmnf_find_path(pairs, js, path, 1));
+    ASSERT_STRN_EQ(path[0], js + f->key.start, f->key.end - f->key.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find_path(pairs, js, path, 2));
+    ASSERT_STRN_EQ(path[1], js + f->key.start, f->key.end - f->key.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find_path(pairs, js, path, 3));
+    ASSERT_STRN_EQ(path[2], js + f->key.start, f->key.end - f->key.start);
+    ASSERT_NEQ(NULL, f = jsmnf_find_path(pairs, js, path, 4));
+    ASSERT_EQm("Array elements shouldn't have a key", 0,
+               f->key.end - f->key.start);
+    ASSERT_STRN_EQ("true", js + f->value.start, f->value.end - f->value.start);
 
     PASS();
 }


### PR DESCRIPTION
Store offset values rather than string pointers, allowing for greater flexibility when duplicating a loaded `jsmnf_pairs` array. Prior to this one would have to keep the same JSON string data kept around for the duplicate.