### PR TITLE
Fix/oa-hash dependency include

### DIFF
--- a/jsmn-find.h
+++ b/jsmn-find.h
@@ -9,7 +9,11 @@ extern "C" {
 #error "jsmn-find.h should be included after jsmn.h"
 #else
 
+#ifdef JSMN_HEADER
+#define OA_HASH_HEADER
+#endif /* JSMN_HEADER */
 #include "oa_hash.h"
+#undef OA_HASH_HEADER
 
 #define JSMNF_PAIR_ATTRS_const                                                \
     /** JSON object or array pair attributes */                               \
@@ -163,6 +167,10 @@ JSMN_API long jsmnf_unescape(char buf[],
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#define OA_HASH_STATIC
+#include "oa_hash.h"
+#undef OA_HASH_STATIC
 
 struct _jsmnf_pair_mut {
     JSMNF_PAIR_ATTRS(mut);


### PR DESCRIPTION
Check whether oa-hash should be included as header-only or static-only